### PR TITLE
added parallel processing for prepare_strainge_db.py

### DIFF
--- a/bin/prepare_strainge_db.py
+++ b/bin/prepare_strainge_db.py
@@ -1,21 +1,13 @@
 #!/usr/bin/env python3
-"""
-Search a directory recursively and collect all reference genomes,
-then symlink each reference genome with a human-readable filename to the
-given output directory. This directory then serves as input for a StrainGST
-database.
 
-The directory structure should follow the `ncbi-genome-download` human readable
-output structure.
-
-This script can optionally split chromosomes and plasmids too.
-"""
-
+import os
 import re
 import gzip
 import logging
 import argparse
 from pathlib import Path
+from multiprocessing import Pool
+from functools import partial
 
 import skbio
 
@@ -47,7 +39,6 @@ def generate_friendly_id(fpath):
 
     return f"{genus}_{species}_{strain}"
 
-
 def read_assembly_report(f):
     attr = {}
     for line in f:
@@ -64,7 +55,6 @@ def read_assembly_report(f):
         attr[key] = value
 
     return attr
-
 
 def split_chrom_plasmids(path):
     chromosomes = []
@@ -92,11 +82,10 @@ def split_chrom_plasmids(path):
     with gzip.open(plasmid_path, "wt") as f:
         for plasmid in plasmids:
             skbio.io.write(plasmid, "fasta", into=f)
-
-
-def search_directory(directory, output_dir, ofile, split_plasmids=False):
+            
+def get_paths(directory):
     used_names = set()
-
+    paths = []
     for fpath in directory.glob("**/*_genomic.fna.gz"):
         if fpath.name.endswith('_cds_from_genomic.fna.gz'):
             continue
@@ -110,42 +99,64 @@ def search_directory(directory, output_dir, ofile, split_plasmids=False):
 
         with assembly_report_path.open() as f:
             attrs = read_assembly_report(f)
-
         accession = attrs['RefSeq assembly accession']
 
         if friendly_id in used_names:
             friendly_id += f"_{accession}"
 
         used_names.add(friendly_id)
+        
+        paths.append([friendly_id,  accession, fpath])
+        logger.info(f'{friendly_id} ({accession}): {fpath}')
+        
+    return paths
 
-        logger.info('%s (%s): %s', friendly_id, accession, fpath)
+def make_symlink(symlink: Path, original: Path, overwrite = True):
+    if overwrite and symlink.is_symlink():
+        symlink.unlink()
+    symlink.symlink_to(original)    
 
-        target_path = output_dir / f"{friendly_id}.fa.gz"
+def prepare_db(x, output_dir, split_plasmids=False):
+    friendly_id, accession, fpath = x
+    target_path = output_dir / f"{friendly_id}.fa.gz"
 
-        if split_plasmids:
-            prefix = fpath.name.replace(".fna.gz", "")
-            chrom_path = fpath.parent / f"{prefix}.chrom.fna.gz"
+    if split_plasmids:
+        prefix = fpath.name.replace(".fna.gz", "")
+        chrom_path = fpath.parent / f"{prefix}.chrom.fna.gz"
 
-            if not chrom_path.is_file():
-                logger.info("No FASTA file found with chromosomes only.")
-                logger.info("Generating %s", chrom_path)
-                split_chrom_plasmids(fpath)
-            else:
-                logger.info("Found chromosome only FASTA file at %s",
-                            chrom_path)
+        if not chrom_path.is_file():
+            logger.info("No FASTA file found with chromosomes only.")
+            logger.info("Generating %s", chrom_path)
+            split_chrom_plasmids(fpath)
+        else:
+            logger.info("Found chromosome only FASTA file at %s",
+                        chrom_path)
 
-            fpath = chrom_path
+        fpath = chrom_path
 
-        target_path.symlink_to(fpath.resolve())
+    # symlink
+    make_symlink(target_path, fpath.resolve())
+    return [friendly_id, str(target_path.resolve()), accession]
 
-        print(friendly_id, str(target_path.resolve()), accession,
-              sep='\t', file=ofile)
-
-
+        
 def main():
+    class CustomFormatter(argparse.ArgumentDefaultsHelpFormatter,
+                      argparse.RawDescriptionHelpFormatter):
+        pass
+    
+    desc = """Search a directory recursively and collect all reference genomes,
+then symlink each reference genome with a human-readable filename to the
+given output directory. This directory then serves as input for a StrainGST
+database.
+
+The directory structure should follow the `ncbi-genome-download` human readable
+output structure.
+
+This script can optionally split chromosomes and plasmids too.
+"""   
     parser = argparse.ArgumentParser(
-        description="Prepare a directory with reference genomes to be used for"
-                    " StrainGE database creation."
+        description=desc,
+        formatter_class=CustomFormatter
     )
 
     parser.add_argument(
@@ -163,16 +174,37 @@ def main():
         help="Output directory. Will contain symlinks to the all references "
              "and a TSV file with some metadata on the included references."
     )
-
+    parser.add_argument(
+        '-t', '--threads', type=int, default=1,
+        help="Number of parallel processes."
+    )
+    
     args = parser.parse_args()
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
+    
+    # getting directory info
+    if args.threads > 1:
+        pool = Pool(args.threads)
+        paths = pool.map(get_paths, args.directories)
+    else:
+        paths = map(get_paths, args.directories)        
+    paths = [y for x in paths for y in x]
+    
+    # preparing db
+    func = partial(prepare_db,
+                   output_dir=args.output_dir,
+                   split_plasmids=args.split_plasmids)
+    if args.threads > 1:
+        res = pool.map(func, paths)
+    else:
+        res = map(func, paths)
 
+    # writing metadata
     metadata_tsv = args.output_dir / "references_meta.tsv"
     with metadata_tsv.open('w') as ofile:
-        for directory in args.directories:
-            search_directory(directory, args.output_dir, ofile,
-                             args.split_plasmids)
+        for x in res:
+            print(x, sep='\t', file=ofile)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Used for testing

```
$SCRIPT_PATH=StrainGE/bin/
rm -rf ref_genomes && \
  ncbi-genome-download -p 8 -l complete -t 817 -H -F fasta,assembly-report -o ref_genomes bacteria && \
  rm -rf strainge_db && \
  mkdir strainge_db && \
  python3 $SCRIPT_PATH/prepare_strainge_db.py ref_genomes/human_readable -t 8 -s -o strainge_db > strainge_db/references_meta.tsv
```